### PR TITLE
change the interface of Transaction#Scan to accept `end` as the std::…

### DIFF
--- a/include/lineairdb/transaction.h
+++ b/include/lineairdb/transaction.h
@@ -159,7 +159,7 @@ class Transaction {
    *
    */
   const std::optional<size_t> Scan(
-      const std::string_view begin, const std::string_view end,
+      const std::string_view begin, const std::optional<std::string_view> end,
       std::function<bool(std::string_view,
                          const std::pair<const void*, const size_t>)>
           operation);
@@ -178,7 +178,7 @@ class Transaction {
    */
   template <typename T>
   const std::optional<size_t> Scan(
-      const std::string_view begin, const std::string_view end,
+      const std::string_view begin, const std::optional<std::string_view> end,
       std::function<bool(std::string_view, T)> operation) {
     static_assert(std::is_trivially_copyable<T>::value == true,
                   "LineairDB expects to trivially copyable types.");

--- a/src/index/concurrent_table.cpp
+++ b/src/index/concurrent_table.cpp
@@ -71,7 +71,7 @@ void ConcurrentTable::ForEach(
 };
 
 std::optional<size_t> ConcurrentTable::Scan(
-    const std::string_view begin, const std::string_view end,
+    const std::string_view begin, const std::optional<std::string_view> end,
     std::function<bool(std::string_view)> operation) {
   return index_->Scan(begin, end, operation);
 };

--- a/src/index/concurrent_table.h
+++ b/src/index/concurrent_table.h
@@ -42,7 +42,7 @@ class ConcurrentTable {
   bool Put(const std::string_view key, DataItem&& value);
   void ForEach(std::function<bool(std::string_view, DataItem&)>);
   std::optional<size_t> Scan(const std::string_view begin,
-                             const std::string_view end,
+                             const std::optional<std::string_view> end,
                              std::function<bool(std::string_view)> operation);
   std::optional<size_t> Scan(
       const std::string_view begin, const std::string_view end,

--- a/src/index/precision_locking_index/index.hpp
+++ b/src/index/precision_locking_index/index.hpp
@@ -60,14 +60,16 @@ class HashTableWithPrecisionLockingIndex {
    * @brief Scan with key and values
    *
    * @param begin Starting point of the range. Matching entry is included.
-   * @param end Ending point of the range. Matching entry isn't included.
+   * @param end Ending point of the range. Matching entry isn't included. If
+   * this parameter is not given (std::nullopt_t is given), this function
+   * continues scanning to the end of index.
    * @param operation This callback function will be invoked for every entry
    * matching the range, The key/value pair will be given as an argument.
    * @return std::optional<size_t> returns std::nullopt if a phantom anomaly has
    * detected.
    */
   std::optional<size_t> Scan(
-      const std::string_view begin, const std::string_view end,
+      const std::string_view begin, const std::optional<std::string_view> end,
       std::function<bool(std::string_view, T&)> operation) {
     return Scan(begin, end, [&](std::string_view key) {
       auto* value = Get(key);
@@ -80,7 +82,7 @@ class HashTableWithPrecisionLockingIndex {
    * range index.
    */
   std::optional<size_t> Scan(const std::string_view begin,
-                             const std::string_view end,
+                             const std::optional<std::string_view> end,
                              std::function<bool(std::string_view)> operation) {
     return range_index_.Scan(begin, end, operation);
   };

--- a/src/index/precision_locking_index/range_index/precision_locking.h
+++ b/src/index/precision_locking_index/range_index/precision_locking.h
@@ -55,7 +55,7 @@ class PrecisionLockingIndex {
   PrecisionLockingIndex(LineairDB::EpochFramework&);
   ~PrecisionLockingIndex();
   std::optional<size_t> Scan(const std::string_view begin,
-                             const std::string_view end,
+                             const std::optional<std::string_view> end,
                              std::function<bool(std::string_view)> operation);
   bool Insert(const std::string_view key);
   void ForceInsert(const std::string_view key);
@@ -64,12 +64,13 @@ class PrecisionLockingIndex {
  private:
   bool IsInPredicateSet(const std::string_view);
   bool IsOverlapWithInsertOrDelete(const std::string_view,
-                                   const std::string_view);
+                                   const std::optional<std::string_view>);
 
   struct Predicate {
     std::string begin;
-    std::string end;
-    Predicate(std::string_view b, std::string_view e) : begin(b), end(e) {}
+    std::optional<std::string> end;
+    Predicate(std::string_view b, std::optional<std::string_view> e)
+        : begin(b), end(e) {}
   };
 
   struct InsertOrDeleteEvent {

--- a/src/transaction_impl.cpp
+++ b/src/transaction_impl.cpp
@@ -125,7 +125,7 @@ void Transaction::Impl::Write(const std::string_view key,
 }
 
 const std::optional<size_t> Transaction::Impl::Scan(
-    const std::string_view begin, const std::string_view end,
+    const std::string_view begin, const std::optional<std::string_view> end,
     std::function<bool(std::string_view,
                        const std::pair<const void*, const size_t>)>
         operation) {
@@ -174,7 +174,7 @@ void Transaction::Write(const std::string_view key, const std::byte value[],
   tx_pimpl_->Write(key, value, size);
 }
 const std::optional<size_t> Transaction::Scan(
-    const std::string_view begin, const std::string_view end,
+    const std::string_view begin, const std::optional<std::string_view> end,
     std::function<bool(std::string_view,
                        const std::pair<const void*, const size_t>)>
         operation) {

--- a/src/transaction_impl.h
+++ b/src/transaction_impl.h
@@ -63,7 +63,7 @@ class Transaction::Impl {
              const size_t size);
 
   const std::optional<size_t> Scan(
-      const std::string_view begin, const std::string_view end,
+      const std::string_view begin, const std::optional<std::string_view> end,
       std::function<bool(std::string_view,
                          const std::pair<const void*, const size_t>)>
           operation);

--- a/tests/unit-tests/index_test.cpp
+++ b/tests/unit-tests/index_test.cpp
@@ -1,0 +1,124 @@
+/*
+ *   Copyright (C) 2020 Nippon Telegraph and Telephone Corporation.
+
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <lineairdb/config.h>
+#include <lineairdb/database.h>
+#include <lineairdb/transaction.h>
+#include <lineairdb/tx_status.h>
+
+#include <memory>
+#include <optional>
+
+#include "../test_helper.hpp"
+#include "gtest/gtest.h"
+
+class IndexTest : public ::testing::Test {
+ protected:
+  LineairDB::Config config_;
+  std::unique_ptr<LineairDB::Database> db_;
+  virtual void SetUp() {
+    config_.enable_recovery      = false;
+    config_.enable_logging       = false;
+    config_.enable_checkpointing = false;
+    db_ = std::make_unique<LineairDB::Database>(config_);
+
+    TestHelper::RetryTransactionUntilCommit(db_.get(), [&](auto& tx) {
+      int alice = 1;
+      int bob   = 2;
+      int carol = 3;
+      tx.template Write<decltype(alice)>("alice", alice);
+      tx.template Write<decltype(bob)>("bob", bob);
+      tx.template Write<decltype(carol)>("carol", carol);
+    });
+    db_->Fence();
+  }
+};
+
+TEST_F(IndexTest, Scan) {
+  auto& tx   = db_->BeginTransaction();
+  auto count = tx.Scan("alice", "bob", [&](auto key, auto) {
+    EXPECT_TRUE(key == "alice" || key == "bob");
+    return false;
+  });
+  ASSERT_TRUE(count.has_value());
+  ASSERT_EQ(2, count.value());  // #Scan is not inclusive
+  db_->EndTransaction(tx, [](auto) {});
+}
+
+TEST_F(IndexTest, AlphabeticalOrdering) {
+  auto& tx   = db_->BeginTransaction();
+  auto count = tx.Scan("carol", "alice", [&](auto, auto) { return false; });
+  ASSERT_FALSE(count.has_value());
+
+  count = tx.Scan("carol", "zzz", [&](auto, auto) { return false; });
+  ASSERT_TRUE(count.has_value());
+  ASSERT_EQ(1, count.value());
+  db_->EndTransaction(tx, [](auto) {});
+}
+
+TEST_F(IndexTest, ScanViaTemplate) {
+  auto& tx   = db_->BeginTransaction();
+  auto count = tx.Scan<int>("alice", "bob", [&](auto key, auto) {
+    EXPECT_TRUE(key == "alice" || key == "bob");
+    return false;
+  });
+  ASSERT_TRUE(count.has_value());
+  ASSERT_EQ(2, count.value());
+  db_->EndTransaction(tx, [](auto) {});
+}
+
+TEST_F(IndexTest, StopScanning) {
+  auto& tx   = db_->BeginTransaction();
+  auto count = tx.Scan("alice", "carol", [&](auto key, auto) {
+    EXPECT_TRUE(key == "alice");
+    EXPECT_FALSE(key == "bob");
+    return true;
+  });
+  ASSERT_TRUE(count.has_value());
+  ASSERT_EQ(1, count.value());
+  db_->EndTransaction(tx, [](auto) {});
+}
+
+TEST_F(IndexTest, ScanWithoutEnd) {
+  auto& tx   = db_->BeginTransaction();
+  auto count = tx.Scan("alice", std::nullopt, [&](auto key, auto) {
+    EXPECT_TRUE(key == "alice" || key == "bob" || key == "carol");
+    return false;
+  });
+  ASSERT_TRUE(count.has_value());
+  ASSERT_EQ(3, count.value());
+  db_->EndTransaction(tx, [](auto) {});
+}
+
+TEST_F(IndexTest, ScanWithPhantomAvoidance) {
+  int dave = 4;
+
+  std::optional<size_t> first, second;
+  const auto committed = TestHelper::DoHandlerTransactionsOnMultiThreads(
+      db_.get(),
+      {[&](LineairDB::Transaction& tx) { tx.Write<int>("dave", dave); },
+       [&](LineairDB::Transaction& tx) {
+         auto scan = [&]() {
+           return tx.Scan("alice", "dave", [&](auto, auto) { return false; });
+         };
+         first = scan();
+         std::this_thread::yield();
+         second = scan();
+       }});
+  if (committed == 2 && first.has_value() && second.has_value()) {
+    ASSERT_EQ(first, second);
+  }
+}


### PR DESCRIPTION
…nullopt to unspecify the upper-bound of the key range